### PR TITLE
Code optimizations and portability improvements

### DIFF
--- a/silver-bun/memaddr.h
+++ b/silver-bun/memaddr.h
@@ -125,16 +125,19 @@ public:
 		return *this;
 	}
 
-	bool CheckOpCodes(const std::vector<uint8_t> vOpcodeArray) const;
-	void Patch(const std::vector<uint8_t> vOpcodeArray) const;
-	void PatchString(const std::string& svString) const;
-	CMemory FindPattern(const std::string& svPattern, const Direction searchDirect = Direction::DOWN, const int opCodesToScan = 512, const ptrdiff_t occurrence = 1) const;
-	CMemory FindPatternSelf(const std::string& svPattern, const Direction searchDirect = Direction::DOWN, const int opCodesToScan = 512, const ptrdiff_t occurrence = 1);
+	bool CheckOpCodes(const std::vector<uint8_t>& vOpcodeArray) const;
+	void Patch(const std::vector<uint8_t>& vOpcodeArray) const;
+	void PatchString(const char* szString) const;
+
+	CMemory FindPattern(const char* szPattern, const Direction searchDirect = Direction::DOWN, const int opCodesToScan = 512, const ptrdiff_t occurrence = 1) const;
+	CMemory FindPatternSelf(const char* szPattern, const Direction searchDirect = Direction::DOWN, const int opCodesToScan = 512, const ptrdiff_t occurrence = 1);
+	std::vector<CMemory> FindAllCallReferences(const uintptr_t sectionBase, const size_t sectionSize);
+
 	CMemory FollowNearCall(const ptrdiff_t opcodeOffset = 0x1, const ptrdiff_t nextInstructionOffset = 0x5) const;
 	CMemory FollowNearCallSelf(const ptrdiff_t opcodeOffset = 0x1, const ptrdiff_t nextInstructionOffset = 0x5);
 	CMemory ResolveRelativeAddress(const ptrdiff_t registerOffset = 0x0, const ptrdiff_t nextInstructionOffset = 0x4) const;
 	CMemory ResolveRelativeAddressSelf(const ptrdiff_t registerOffset = 0x0, const ptrdiff_t nextInstructionOffset = 0x4);
-	std::vector<CMemory> FindAllCallReferences(const uintptr_t sectionBase, const size_t sectionSize);
+
 	static void HookVirtualMethod(const uintptr_t virtualTable, const void* pHookMethod, const ptrdiff_t methodIndex, void** ppOriginalMethod);
 	static void HookImportedFunction(const uintptr_t pImportedMethod, const void* pHookMethod, void** ppOriginalMethod);
 

--- a/silver-bun/module.h
+++ b/silver-bun/module.h
@@ -19,41 +19,40 @@ public:
 	struct ModuleSections_t
 	{
 		ModuleSections_t(void) = default;
-		ModuleSections_t(const std::string& svSectionName, uintptr_t pSectionBase, size_t nSectionSize) :
-			m_svSectionName(svSectionName), m_pSectionBase(pSectionBase), m_nSectionSize(nSectionSize) {}
+		ModuleSections_t(const char* sectionName, uintptr_t pSectionBase, size_t nSectionSize) :
+			m_SectionName(sectionName), m_pSectionBase(pSectionBase), m_nSectionSize(nSectionSize) {}
 
-		bool IsSectionValid(void) const
-		{
-			return m_nSectionSize != 0;
-		}
+		inline bool IsSectionValid(void) const { return m_nSectionSize != 0; }
 
-		std::string m_svSectionName;         // Name of section.
+		std::string m_SectionName;           // Name of section.
 		uintptr_t   m_pSectionBase;          // Start address of section.
 		size_t      m_nSectionSize;          // Size of section.
 	};
 
 	CModule(void) = default;
-	CModule(const std::string& moduleName);
-	CModule(const uintptr_t nModuleBase, const std::string& svModuleName);
+	CModule(const char* szModuleName);
+	CModule(const char* szModuleName, const uintptr_t nModuleBase);
+
 	void Init();
 	void LoadSections();
 
-	CMemory FindPatternSIMD(const std::string& svPattern, const ModuleSections_t* moduleSection = nullptr) const;
-	CMemory FindString(const std::string& string, const ptrdiff_t occurrence = 1, bool nullTerminator = false) const;
-	CMemory FindStringReadOnly(const std::string& svString, bool nullTerminator) const;
+	CMemory FindPatternSIMD(const char* szPattern, const ModuleSections_t* moduleSection = nullptr) const;
+	CMemory FindString(const char* szString, const ptrdiff_t occurrence = 1, bool nullTerminator = false) const;
+	CMemory FindStringReadOnly(const char* szString, bool nullTerminator) const;
+	CMemory FindFreeDataPage(const size_t nSize) const;
 
-	CMemory          GetVirtualMethodTable(const std::string& svTableName, const uint32_t nRefIndex = 0);
-	CMemory          GetExportedFunction(const std::string& svFunctionName) const;
-	CMemory          GetImportedFunction(const std::string& svModuleName, const std::string& svFunctionName, const bool bGetFunctionReference = false) const;
-	uintptr_t        GetModuleBase(void) const;
-	DWORD            GetModuleSize(void) const;
-	std::string      GetModuleName(void) const;
-	uintptr_t        GetRVA(const uintptr_t nAddress) const;
-	ModuleSections_t GetSectionByName(const std::string& svSectionName) const;
-	std::vector<CModule::ModuleSections_t>& GetSections();
-	
-	void UnlinkFromPEB(void);
-	CMemory FindFreeDataPage(const size_t nSize);
+	CMemory          GetVirtualMethodTable(const char* szTableName, const size_t nRefIndex = 0);
+	CMemory          GetImportedFunction(const char* szModuleName, const char* szFunctionName, const bool bGetFunctionReference) const;
+	CMemory          GetExportedFunction(const char* szFunctionName) const;
+	ModuleSections_t GetSectionByName(const char* szSectionName) const;
+
+	inline const vector<CModule::ModuleSections_t>& GetSections() const { return m_ModuleSections; }
+	inline uintptr_t     GetModuleBase(void) const { return m_pModuleBase; }
+	inline DWORD         GetModuleSize(void) const { return m_nModuleSize; }
+	inline const string& GetModuleName(void) const { return m_ModuleName; }
+	inline uintptr_t     GetRVA(const uintptr_t nAddress) const { return (nAddress - GetModuleBase()); }
+
+	void             UnlinkFromPEB(void) const;
 
 	IMAGE_NT_HEADERS64*      m_pNTHeaders;
 	IMAGE_DOS_HEADER*        m_pDOSHeader;
@@ -64,10 +63,11 @@ public:
 	ModuleSections_t         m_ReadOnlyData;
 
 private:
-	CMemory FindPatternSIMD(const uint8_t* szPattern, const char* szMask, const ModuleSections_t* moduleSection = nullptr, const uint32_t nOccurrence = 0) const;
+	CMemory FindPatternSIMD(const uint8_t* pPattern, const char* szMask,
+		const ModuleSections_t* moduleSection = nullptr, const size_t nOccurrence = 0) const;
 
-	std::string                   m_svModuleName;
+	std::string                   m_ModuleName;
 	uintptr_t                     m_pModuleBase;
 	DWORD                         m_nModuleSize;
-	std::vector<ModuleSections_t> m_vModuleSections;
+	std::vector<ModuleSections_t> m_ModuleSections;
 };

--- a/silver-bun/utils.cpp
+++ b/silver-bun/utils.cpp
@@ -5,13 +5,13 @@ namespace Utils
     //----------------------------------------------------------------------------------------
     // Purpose: For converting a string pattern with wildcards to an array of bytes.
     //----------------------------------------------------------------------------------------
-    std::vector<int> PatternToBytes(const std::string& svInput)
+    std::vector<int> PatternToBytes(const char* szInput)
     {
-        char* pszPatternStart = const_cast<char*>(svInput.c_str());
-        char* pszPatternEnd = pszPatternStart + strlen(svInput.c_str());
-        std::vector<int> vBytes = std::vector<int>{ };
+        const char* pszPatternStart = const_cast<char*>(szInput);
+        const char* pszPatternEnd = pszPatternStart + strlen(szInput);
+        std::vector<int> vBytes;
 
-        for (char* pszCurrentByte = pszPatternStart; pszCurrentByte < pszPatternEnd; ++pszCurrentByte)
+        for (const char* pszCurrentByte = pszPatternStart; pszCurrentByte < pszPatternEnd; ++pszCurrentByte)
         {
             if (*pszCurrentByte == '?')
             {
@@ -24,7 +24,7 @@ namespace Utils
             }
             else
             {
-                vBytes.push_back(strtoul(pszCurrentByte, &pszCurrentByte, 16));
+                vBytes.push_back(strtoul(pszCurrentByte, const_cast<char**>(&pszCurrentByte), 16));
             }
         }
         return vBytes;
@@ -33,14 +33,15 @@ namespace Utils
     //----------------------------------------------------------------------------------------
     // Purpose: For converting a string pattern with wildcards to an array of bytes and mask.
     //----------------------------------------------------------------------------------------
-    std::pair<std::vector<uint8_t>, std::string> PatternToMaskedBytes(const std::string& svInput)
+    std::pair<std::vector<uint8_t>, std::string> PatternToMaskedBytes(const char* szInput)
     {
-        char* pszPatternStart = const_cast<char*>(svInput.c_str());
-        char* pszPatternEnd = pszPatternStart + strlen(svInput.c_str());
-        std::vector<uint8_t> vBytes = std::vector<uint8_t>{ };
-        std::string svMask = std::string();
+        const char* pszPatternStart = const_cast<char*>(szInput);
+        const char* pszPatternEnd = pszPatternStart + strlen(szInput);
 
-        for (char* pszCurrentByte = pszPatternStart; pszCurrentByte < pszPatternEnd; ++pszCurrentByte)
+        std::vector<uint8_t> vBytes;
+        std::string svMask;
+
+        for (const char* pszCurrentByte = pszPatternStart; pszCurrentByte < pszPatternEnd; ++pszCurrentByte)
         {
             if (*pszCurrentByte == '?')
             {
@@ -50,12 +51,12 @@ namespace Utils
                     ++pszCurrentByte; // Skip double wildcard.
                 }
                 vBytes.push_back(0); // Push the byte back as invalid.
-                svMask.append("?");
+                svMask += '?';
             }
             else
             {
-                vBytes.push_back(strtoul(pszCurrentByte, &pszCurrentByte, 16));
-                svMask.append("x");
+                vBytes.push_back(uint8_t(strtoul(pszCurrentByte, const_cast<char**>(&pszCurrentByte), 16)));
+                svMask += 'x';
             }
         }
         return make_pair(vBytes, svMask);
@@ -64,13 +65,13 @@ namespace Utils
     //----------------------------------------------------------------------------------------
     // Purpose: For converting a string to an array of bytes.
     //----------------------------------------------------------------------------------------
-    std::vector<int> StringToBytes(const std::string& svInput, bool bNullTerminator)
+    std::vector<int> StringToBytes(const char* szInput, bool bNullTerminator)
     {
-        char* pszStringStart = const_cast<char*>(svInput.c_str());
-        char* pszStringEnd = pszStringStart + strlen(svInput.c_str());
-        std::vector<int> vBytes = std::vector<int>{ };
+        const char* pszStringStart = const_cast<char*>(szInput);
+        const char* pszStringEnd = pszStringStart + strlen(szInput);
+        std::vector<int> vBytes;
 
-        for (char* pszCurrentByte = pszStringStart; pszCurrentByte < pszStringEnd; ++pszCurrentByte)
+        for (const char* pszCurrentByte = pszStringStart; pszCurrentByte < pszStringEnd; ++pszCurrentByte)
         {
             // Dereference character and push back the byte.
             vBytes.push_back(*pszCurrentByte);
@@ -78,7 +79,7 @@ namespace Utils
 
         if (bNullTerminator)
         {
-            vBytes.push_back(0x0);
+            vBytes.push_back('\0');
         }
         return vBytes;
     };
@@ -86,24 +87,24 @@ namespace Utils
     //----------------------------------------------------------------------------------------
     // Purpose: For converting a string to an array of masked bytes.
     //----------------------------------------------------------------------------------------
-    std::pair<std::vector<uint8_t>, std::string> StringToMaskedBytes(const std::string& svInput, bool bNullTerminator)
+    std::pair<std::vector<uint8_t>, std::string> StringToMaskedBytes(const char* szInput, bool bNullTerminator)
     {
-        char* pszStringStart = const_cast<char*>(svInput.c_str());
-        char* pszStringEnd = pszStringStart + strlen(svInput.c_str());
-        std::vector<uint8_t> vBytes = std::vector<uint8_t>{ };
-        std::string svMask = std::string();
+        const char* pszStringStart = const_cast<char*>(szInput);
+        const char* pszStringEnd = pszStringStart + strlen(szInput);
+        std::vector<uint8_t> vBytes;
+        std::string svMask;
 
-        for (char* pszCurrentByte = pszStringStart; pszCurrentByte < pszStringEnd; ++pszCurrentByte)
+        for (const char* pszCurrentByte = pszStringStart; pszCurrentByte < pszStringEnd; ++pszCurrentByte)
         {
             // Dereference character and push back the byte.
             vBytes.push_back(*pszCurrentByte);
-            svMask.append("x");
+            svMask += 'x';
         }
 
         if (bNullTerminator)
         {
             vBytes.push_back(0x0);
-            svMask.append("x");
+            svMask += 'x';
         }
         return make_pair(vBytes, svMask);
     };

--- a/silver-bun/utils.h
+++ b/silver-bun/utils.h
@@ -12,10 +12,10 @@
 
 namespace Utils
 {
-    std::vector<int> PatternToBytes(const std::string& svInput);
-    std::pair<std::vector<uint8_t>, std::string> PatternToMaskedBytes(const std::string& svInput);
-    std::vector<int> StringToBytes(const std::string& svInput, bool bNullTerminator);
-    std::pair<std::vector<uint8_t>, std::string> StringToMaskedBytes(const std::string& svInput, bool bNullTerminator);
+    std::vector<int> PatternToBytes(const char* szInput);
+    std::pair<std::vector<uint8_t>, std::string> PatternToMaskedBytes(const char* szInput);
+    std::vector<int> StringToBytes(const char* szInput, bool bNullTerminator);
+    std::pair<std::vector<uint8_t>, std::string> StringToMaskedBytes(const char* szInput, bool bNullTerminator);
 }
 
 typedef const unsigned char* rsig_t;


### PR DESCRIPTION
- Add support for earlier versions of Visual Studio 2017.
- Removed all extraneous std::string and std::vector copy constructions; use raw pointers instead to boost performance for larger projects.
- Marked simple getters in CModule inline.
- Marked several functions in CModule const.
- Slightly reordered CModule class.
- 'CMemory::CheckOpCodes' and 'CMemory::Patch' now take a const reference.